### PR TITLE
docs: update repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ mail-trash-sorter/
 
 1. **Clone the repository**
    ```bash
-   git clone <your-repo-url>
+   git clone https://github.com/NikitchenkoE/mail-trash-sorter.git
    cd mail-trash-sorter
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/mail-trash-sorter"
-Repository = "https://github.com/yourusername/mail-trash-sorter"
-Issues = "https://github.com/yourusername/mail-trash-sorter/issues"
+Homepage = "https://github.com/NikitchenkoE/mail-trash-sorter"
+Repository = "https://github.com/NikitchenkoE/mail-trash-sorter"
+Issues = "https://github.com/NikitchenkoE/mail-trash-sorter/issues"
 
 [project.scripts]
 mailbot = "mailbot.app.main:main"


### PR DESCRIPTION
This PR updates the repository URLs in both README.md and pyproject.toml to reflect the actual GitHub repository location.

## Changes
- ✅ Updated README.md clone URL from placeholder to actual repository URL
- ✅ Updated pyproject.toml URLs (homepage, repository, issues) to point to the correct GitHub repository

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

This ensures that users can properly clone the repository and that package metadata points to the correct locations.